### PR TITLE
Update landscapist 2.5.0 to 2.5.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.11.0"
 android-compileSdk = "35"
 android-minSdk = "24"
 android-targetSdk = "35"
@@ -10,8 +10,8 @@ compose-multiplatform = "1.8.2"
 kotlin = "2.2.0"
 ktor-client = "3.1.3"
 precompose = "1.6.2"
-landScapist = "2.5.0"
-androidx-lifecycle = "2.8.3"
+landScapist = "2.5.1"
+androidx-lifecycle = "2.9.1"
 buildConfig = "5.6.7"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update landscapist 2.5.0 to 2.5.1
- Update lifecycle 2.8.3 to 2.9.1