### PR TITLE
Update Gradle and LandScapist versions

### DIFF
--- a/composeApp/src/commonMain/kotlin/ui/App.kt
+++ b/composeApp/src/commonMain/kotlin/ui/App.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -225,7 +226,7 @@ fun isBackButtonEnable(navigator: Navigator): Boolean {
         }
     }
 }
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TabScreen(navigator: Navigator, pagerState: PagerState, padding: PaddingValues) {
     val coroutineScope = rememberCoroutineScope()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ compose-multiplatform = "1.9.0"
 kotlin = "2.2.20"
 ktor-client = "3.3.0"
 precompose = "1.6.2"
-landScapist = "2.5.2"
+landScapist = "2.6.0"
 androidx-lifecycle = "2.9.4"
 build-config = "5.6.8"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Gradle version updated from 8.13 to 9.0.0
- LandScapist version updated from 2.5.2 to 2.6.0
- androidx-lifecycle version updated from 2.9.3 to 2.9.4