### PR TITLE
Refactor: Enable edge-to-edge display and adjust app bar visibility

### DIFF
--- a/composeApp/src/androidMain/kotlin/piashcse/kmp/movie/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/piashcse/kmp/movie/MainActivity.kt
@@ -7,11 +7,17 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // Ensure the decor fits system windows
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        
         setContent {
             App()
         }


### PR DESCRIPTION
- Enabled edge-to-edge display in `MainActivity`.
- Modified `App.kt` to handle system window insets and conditionally show/hide the app bar based on search state.
- Search UI is now displayed correctly with edge-to-edge.
- Content is padded correctly when the app bar is visible.