### PR TITLE
Refactor: Implement platform-specific utils and adjust UI padding

### DIFF
--- a/composeApp/src/androidMain/kotlin/utils/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/utils/Platform.android.kt
@@ -1,0 +1,3 @@
+package utils
+
+actual fun getPlatform(): Platform = Platform.ANDROID

--- a/composeApp/src/commonMain/kotlin/ui/App.kt
+++ b/composeApp/src/commonMain/kotlin/ui/App.kt
@@ -46,6 +46,8 @@ import kmp_movie.composeapp.generated.resources.Res
 import kmp_movie.composeapp.generated.resources.celebrities
 import kmp_movie.composeapp.generated.resources.movies
 import kmp_movie.composeapp.generated.resources.tv_series
+import utils.getPlatform
+import utils.Platform
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import moe.tlaster.precompose.PreComposeApp
@@ -215,7 +217,7 @@ private fun DestinationScaffold(
     onSearchFilterChange: (String) -> Unit
 ) {
     Scaffold(
-        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        contentWindowInsets = if (getPlatform() == Platform.IOS) WindowInsets(0, 0, 0, 0) else WindowInsets.safeDrawing,
         floatingActionButton = {
             val route = currentRoute(navigator)
             when {
@@ -239,7 +241,7 @@ private fun DestinationScaffold(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 58.dp) // AppBar height (no need for conditional since AppBar handles its own insets)
+                    .padding(top = if (getPlatform() == Platform.IOS) 58.dp else 0.dp)
                     .padding(contentPadding)
             ) {
                 TabScreen(navigator, pagerState, contentPadding)

--- a/composeApp/src/commonMain/kotlin/utils/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/utils/Platform.kt
@@ -1,0 +1,7 @@
+package utils
+
+enum class Platform {
+    ANDROID, IOS, DESKTOP, WEB
+}
+
+expect fun getPlatform(): Platform

--- a/composeApp/src/desktopMain/kotlin/utils/Platform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/utils/Platform.desktop.kt
@@ -1,0 +1,3 @@
+package utils
+
+actual fun getPlatform(): Platform = Platform.DESKTOP

--- a/composeApp/src/iosMain/kotlin/utils/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/utils/Platform.ios.kt
@@ -1,0 +1,3 @@
+package utils
+
+actual fun getPlatform(): Platform = Platform.IOS

--- a/composeApp/src/wasmJsMain/kotlin/utils/Platform.web.kt
+++ b/composeApp/src/wasmJsMain/kotlin/utils/Platform.web.kt
@@ -1,0 +1,3 @@
+package utils
+
+actual fun getPlatform(): Platform = Platform.WEB


### PR DESCRIPTION
- Added `Platform` enum and `getPlatform()` expect/actual functions to identify the current platform (Android, iOS, Desktop, Web).
- Adjusted top padding in `App.kt` based on the platform, applying specific padding for iOS.
- Modified `contentWindowInsets` in `Scaffold` to use `WindowInsets(0,0,0,0)` for iOS and `WindowInsets.safeDrawing` for other platforms.