### PR TITLE
docs: Update README and build: Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # KMP Movie (Compose Multiplatform)
 
-[![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-v1.10.2-green)](https://developer.android.com/jetpack/compose)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.10-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
-[![ktorCleint](https://img.shields.io/badge/ktor_client-3.4.1-pink)](https://ktor.io/docs/welcome.html)
+[![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-v1.10.3-green)](https://developer.android.com/jetpack/compose)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+[![ktorCleint](https://img.shields.io/badge/ktor_client-3.4.2-pink)](https://ktor.io/docs/welcome.html)
 ![badge-Android](https://img.shields.io/badge/Platform-Android-brightgreen)
 ![badge-iOS](https://img.shields.io/badge/Platform-iOS-lightgray)
 ![badge-desktop](http://img.shields.io/badge/Platform-Desktop-4D76CD.svg?style=flat)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -66,7 +66,6 @@ kotlin {
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.client.logging)
             implementation(libs.androidx.navigation3.ui)
-            implementation(libs.androidx.navigation3.material3.adaptive)
             implementation(libs.landscapist.coil)
             implementation(libs.landscapist.animation)
             implementation(libs.androidx.lifecycle)

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ android.nonTransitiveRClass=true
 android.useAndroidX=true
 
 #Native
-kotlin.native.cacheKind=none
 android.defaults.buildfeatures.resvalues=true
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.enableAppCompileTimeRClass=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,20 +3,19 @@ agp = "9.1.0"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
-androidx-activity-compose = "1.12.4"
-compose = "1.10.4"
+androidx-activity-compose = "1.13.0"
+compose = "1.10.6"
 compose-adaptive = "1.2.0"
 compose-material3 = "1.9.0"
-compose-multiplatform = "1.10.2"
-kotlin = "2.3.10"
+compose-multiplatform = "1.10.3"
+kotlin = "2.3.20"
 coroutines = "1.10.2"
-ktor-client = "3.4.1"
+ktor-client = "3.4.2"
 androidxNavigation3 = "1.0.0-alpha06"
-androidxNavigation3Material = "1.3.0-alpha03"
-landScapist = "2.9.5"
-androidx-lifecycle = "2.9.6"
+landScapist = "2.9.6"
+androidx-lifecycle = "2.10.0"
 build-config = "6.0.9"
-koin = "4.1.1"
+koin = "4.2.1"
 kotlinx-datetime = "0.7.1"
 multiplatform-settings = "1.3.0"
 
@@ -37,7 +36,6 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor-client" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor-client" }
 androidx-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "androidxNavigation3" }
-androidx-navigation3-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation3", version.ref = "androidxNavigation3Material" }
 landscapist-coil = { module = "com.github.skydoves:landscapist-coil3", version.ref = "landScapist" }
 landscapist-animation = { module = "com.github.skydoves:landscapist-animation", version.ref = "landScapist" }
 androidx-lifecycle = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
- Updated Kotlin from `2.3.10` to `2.3.20`.
- Updated `compose-multiplatform` from `1.10.2` to `1.10.3`.
- Updated `compose` from `1.10.4` to `1.10.6`.
- Updated `ktor-client` from `3.4.1` to `3.4.2`.
- Updated `androidx-activity-compose` from `1.12.4` to `1.13.0`.
- Updated `landScapist` from `2.9.5` to `2.9.6`.
- Updated `androidx-lifecycle` from `2.9.6` to `2.10.0`.
- Updated `koin` from `4.1.1` to `4.2.1`.
- Removed `androidx-navigation3-material3-adaptive` dependency.
- Removed `kotlin.native.cacheKind=none` from `gradle.properties`.
- Updated version badges in `README.md`.